### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.1.0...btdt-cli-v0.2.0) - 2025-09-13
+
+### Other
+
+- Update formatting
+- Upgrade to Rust edition 2024
+- Allow caches to be shared across threads
+- Make use of improved format string syntax
+- Extend motivation section with caching problems on Tekton
+- Provide file size when getting a file from cache
+- Provide file size when getting a file from storage
+- Benchmark StreamAdapter
+- Extract method for creating a filled file
+- Remove BufReader
+- Add benchmarks for store/restore
+- Collapse if statements
+- Fix new clippy warning
+- Implement Send for cache Meta
+- Make InMemoryStorage fully Send + Sync
+- Remove no longer required RefCell from LocalCache
+- Eliminate warning about unused variable
+- Use thread-safe interior mutability for storage
+- Remove unnecessary &mut from Storage::exists_file
+- Simplify error constructor
+
 ## 0.1.0 - 2025-03-01
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "bytes 1.10.1",
  "config",
  "criterion",
+ "fs2",
  "futures-core",
  "poem",
  "poem-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.1.0" }
+btdt = { path = "../btdt", version = "0.2.0" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/CHANGELOG.md
+++ b/btdt-server/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jgosmann/btdt/releases/tag/btdt-server-v0.1.0) - 2025-09-13
+
+### Other
+
+- Make use of `size_hint` in `StreamAdapter`
+- Provide file size when getting a file from cache
+- Optimize StreamAdapter buffer size
+- Benchmark StreamAdapter
+- Move StreamAdapter to separate module
+- Improve reading of cache entry
+- Use spawn_blocking to offload blocking I/O when reading from cache
+- Replace put implementation with SyncIoBridge and spawn_blocking
+- Set correct API prefix
+- Upgrade to Rust edition 2024
+- Implement remote cache endpoints
+- Print version info on server startup
+- Implement TLS support
+- Test config for enabling/disabling API docs
+- Test parsing of config
+- Allow disabling API docs
+- Add configuration for bind addresses to btdt-server
+- Add Swagger UI documentation
+- Add integration test for btdt-server
+- Add btdt-server with simple health endpoint

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -8,7 +8,7 @@ name = "asyncio"
 path = "lib/asyncio.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.1.0" }
+btdt = { path = "../btdt", version = "0.2.0" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -20,6 +20,7 @@ tokio-util = { version = "0.7.16", features = ["io", "io-util"] }
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["cargo_bench_support", "plotters", "rayon", "async_tokio"] }
+fs2 = "0.4.3"
 poem = { version = "3", features = ["test"] }
 rand_core = "0.9.3"
 rand_xoshiro = "0.7.0"

--- a/btdt-server/benches/asyncio.rs
+++ b/btdt-server/benches/asyncio.rs
@@ -1,6 +1,7 @@
 use asyncio::StreamAdapter;
 use btdt::test_util::fs::CreateFilled;
 use criterion::{Criterion, criterion_group, criterion_main};
+use fs2::FileExt;
 use rand_core::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::fs::File;
@@ -39,7 +40,7 @@ pub fn bench_stream_adapter(c: &mut Criterion) {
         group.bench_function(format!("Read {} KiB bytes", size_kB), |b| {
             b.to_async(&harness.runtime).iter(async || {
                 let mut stream_adapter =
-                    StreamAdapter::new(Box::new(File::open(&input_path).unwrap()));
+                    StreamAdapter::new(Box::new(File::open(&input_path).unwrap()), size as u64);
                 while let Some(chunk) = stream_adapter.next().await {
                     black_box(chunk.unwrap());
                 }

--- a/btdt-server/src/app/cache_dispatcher.rs
+++ b/btdt-server/src/app/cache_dispatcher.rs
@@ -17,14 +17,28 @@ impl Cache for CacheDispatcher {
 
     fn get<'a>(&self, keys: &[&'a str]) -> io::Result<Option<CacheHit<'a, Self::Reader>>> {
         Ok(match self {
-            Self::InMemory(cache) => cache.get(keys)?.map(|CacheHit { key, reader }| CacheHit {
-                key,
-                reader: Box::new(reader) as Box<dyn Read + Send>,
-            }),
-            Self::Filesystem(cache) => cache.get(keys)?.map(|CacheHit { key, reader }| CacheHit {
-                key,
-                reader: Box::new(reader) as Box<dyn Read + Send>,
-            }),
+            Self::InMemory(cache) => cache.get(keys)?.map(
+                |CacheHit {
+                     key,
+                     reader,
+                     size_hint,
+                 }| CacheHit {
+                    key,
+                    reader: Box::new(reader) as Box<dyn Read + Send>,
+                    size_hint,
+                },
+            ),
+            Self::Filesystem(cache) => cache.get(keys)?.map(
+                |CacheHit {
+                     key,
+                     reader,
+                     size_hint,
+                 }| CacheHit {
+                    key,
+                    reader: Box::new(reader) as Box<dyn Read + Send>,
+                    size_hint,
+                },
+            ),
         })
     }
 

--- a/btdt-server/src/app/get_from_cache.rs
+++ b/btdt-server/src/app/get_from_cache.rs
@@ -26,6 +26,7 @@ where
     fn from(hit: CacheHit<R>) -> Self {
         GetFromCacheResponse::CacheHit(Binary(Body::from_bytes_stream(StreamAdapter::new(
             Box::new(hit.reader),
+            hit.size_hint,
         ))))
     }
 }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"

--- a/btdt/src/cache.rs
+++ b/btdt/src/cache.rs
@@ -46,4 +46,7 @@ pub struct CacheHit<'a, Reader: Read> {
 
     /// Reader for the cached data.
     pub reader: Reader,
+
+    /// (Approximate) size of the cached data in bytes.
+    pub size_hint: u64,
 }

--- a/btdt/src/cache/local.rs
+++ b/btdt/src/cache/local.rs
@@ -119,6 +119,7 @@ impl<S: Storage, C: Clock, R: RngBytes> Cache for LocalCache<S, C, R> {
                             return Ok(Some(CacheHit {
                                 key,
                                 reader: file_handle.reader,
+                                size_hint: file_handle.size_hint,
                             }));
                         }
                         Err(err) => match err.kind() {
@@ -513,7 +514,11 @@ mod tests {
         matched_key: &str,
         content: &str,
     ) {
-        let CacheHit { key, mut reader } = cache
+        let CacheHit {
+            key,
+            mut reader,
+            size_hint,
+        } = cache
             .get(keys)
             .expect("IO failure getting cache entry")
             .expect("cache entry not found");
@@ -527,6 +532,7 @@ mod tests {
             .read_to_string(&mut buf)
             .expect("failed to read cache entry");
         assert_eq!(buf, content, "cache entry content mismatch");
+        assert_eq!(size_hint, content.len() as u64);
     }
 
     fn assert_no_cache_entry<C: Cache>(cache: &C, keys: &[&str]) {

--- a/btdt/src/storage.rs
+++ b/btdt/src/storage.rs
@@ -40,8 +40,8 @@ pub trait Storage {
     /// Checks if a file exists at the given path.
     fn exists_file(&self, path: &str) -> io::Result<bool>;
 
-    /// Returns a reader for the file at the given path.
-    fn get(&self, path: &str) -> io::Result<Self::Reader>;
+    /// Returns a `FileHandle` for the file at the given path.
+    fn get(&self, path: &str) -> io::Result<FileHandle<Self::Reader>>;
 
     /// Returns an iterator over the entries in the directory at the given path.
     fn list(&self, path: &str) -> io::Result<impl Iterator<Item = io::Result<StorageEntry<'_>>>>;
@@ -54,6 +54,15 @@ pub trait Storage {
     /// The implementation must ensure that the file becomes available atomically when
     /// [Close::close] is called. It also must create intermediate directories if necessary.
     fn put(&self, path: &str) -> io::Result<Self::Writer>;
+}
+
+/// A handle to a file in the storage, containing its size and a reader for its content.
+pub struct FileHandle<Reader: Read> {
+    /// The (approximate) size of the file in bytes.
+    pub size_hint: u64,
+
+    /// A reader for the file content.
+    pub reader: Reader,
 }
 
 /// The type of entry when listing a storage directory.

--- a/btdt/src/storage/tests.rs
+++ b/btdt/src/storage/tests.rs
@@ -201,8 +201,8 @@ pub fn write_file_to_storage(storage: &impl Storage, path: &str, content: &str) 
 }
 
 pub fn read_file_from_storage_to_string(storage: &impl Storage, path: &str) -> io::Result<String> {
-    let mut reader = storage.get(path)?;
+    let mut handle = storage.get(path)?;
     let mut buf = String::new();
-    reader.read_to_string(&mut buf)?;
+    handle.reader.read_to_string(&mut buf)?;
     Ok(buf)
 }


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `btdt-cli`: 0.1.0 -> 0.2.0
* `btdt-server`: 0.1.0

### ⚠ `btdt` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CacheHit.size_hint in /tmp/.tmp5qfkT1/btdt/btdt/src/cache.rs:51

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type InMemoryStorage no longer derives Clone, in /tmp/.tmp5qfkT1/btdt/btdt/src/storage/in_memory.rs:46
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.2.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.1.0...btdt-cli-v0.2.0) - 2025-09-13

### Other

- Update formatting
- Upgrade to Rust edition 2024
- Allow caches to be shared across threads
- Make use of improved format string syntax
- Extend motivation section with caching problems on Tekton
- Provide file size when getting a file from cache
- Provide file size when getting a file from storage
- Benchmark StreamAdapter
- Extract method for creating a filled file
- Remove BufReader
- Add benchmarks for store/restore
- Collapse if statements
- Fix new clippy warning
- Implement Send for cache Meta
- Make InMemoryStorage fully Send + Sync
- Remove no longer required RefCell from LocalCache
- Eliminate warning about unused variable
- Use thread-safe interior mutability for storage
- Remove unnecessary &mut from Storage::exists_file
- Simplify error constructor
</blockquote>

## `btdt-server`

<blockquote>

## [0.1.0](https://github.com/jgosmann/btdt/releases/tag/btdt-server-v0.1.0) - 2025-09-13

### Other

- Make use of `size_hint` in `StreamAdapter`
- Provide file size when getting a file from cache
- Optimize StreamAdapter buffer size
- Benchmark StreamAdapter
- Move StreamAdapter to separate module
- Improve reading of cache entry
- Use spawn_blocking to offload blocking I/O when reading from cache
- Replace put implementation with SyncIoBridge and spawn_blocking
- Set correct API prefix
- Upgrade to Rust edition 2024
- Implement remote cache endpoints
- Print version info on server startup
- Implement TLS support
- Test config for enabling/disabling API docs
- Test parsing of config
- Allow disabling API docs
- Add configuration for bind addresses to btdt-server
- Add Swagger UI documentation
- Add integration test for btdt-server
- Add btdt-server with simple health endpoint
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).