### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.1.0...btdt-cli-v0.2.0) - 2025-09-14
+
+### Other
+
+- Update formatting
+- Upgrade to Rust edition 2024
+- Allow caches to be shared across threads
+- Make use of improved format string syntax
+- Extend motivation section with caching problems on Tekton
+- Provide file size when getting a file from cache
+- Provide file size when getting a file from storage
+- Benchmark StreamAdapter
+- Extract method for creating a filled file
+- Remove BufReader
+- Add benchmarks for store/restore
+- Collapse if statements
+- Fix new clippy warning
+- Implement Send for cache Meta
+- Make InMemoryStorage fully Send + Sync
+- Remove no longer required RefCell from LocalCache
+- Eliminate warning about unused variable
+- Use thread-safe interior mutability for storage
+- Remove unnecessary &mut from Storage::exists_file
+- Simplify error constructor
+
 ## 0.1.0 - 2025-03-01
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "btdt",
  "bytes 1.10.1",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.1.0" }
+btdt = { path = "../btdt", version = "0.2.0" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lib]
@@ -8,7 +8,7 @@ name = "asyncio"
 path = "lib/asyncio.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.1.0" }
+btdt = { path = "../btdt", version = "0.2.0" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,3 +12,10 @@ changelog_include = ["btdt"]
 changelog_path = "CHANGELOG.md"
 git_release_name = "v{{ version }}"
 version_group = "btdt"
+
+[[package]]
+name = "btdt-server"
+changelog_include = ["btdt"]
+changelog_path = "CHANGELOG.md"
+git_release_name = "v{{ version }}"
+version_group = "btdt"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `btdt-cli`: 0.1.0 -> 0.2.0
* `btdt-server`: 0.1.0 -> 0.2.0

### ⚠ `btdt` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CacheHit.size_hint in /tmp/.tmp4OnrIy/btdt/btdt/src/cache.rs:51

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type InMemoryStorage no longer derives Clone, in /tmp/.tmp4OnrIy/btdt/btdt/src/storage/in_memory.rs:46
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.2.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.1.0...btdt-cli-v0.2.0) - 2025-09-14

### Other

- Update formatting
- Upgrade to Rust edition 2024
- Allow caches to be shared across threads
- Make use of improved format string syntax
- Extend motivation section with caching problems on Tekton
- Provide file size when getting a file from cache
- Provide file size when getting a file from storage
- Benchmark StreamAdapter
- Extract method for creating a filled file
- Remove BufReader
- Add benchmarks for store/restore
- Collapse if statements
- Fix new clippy warning
- Implement Send for cache Meta
- Make InMemoryStorage fully Send + Sync
- Remove no longer required RefCell from LocalCache
- Eliminate warning about unused variable
- Use thread-safe interior mutability for storage
- Remove unnecessary &mut from Storage::exists_file
- Simplify error constructor
</blockquote>

## `btdt-server`

<blockquote>

## [0.2.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.1.0...btdt-cli-v0.2.0) - 2025-09-14

### Other

- Update formatting
- Upgrade to Rust edition 2024
- Allow caches to be shared across threads
- Make use of improved format string syntax
- Extend motivation section with caching problems on Tekton
- Provide file size when getting a file from cache
- Provide file size when getting a file from storage
- Benchmark StreamAdapter
- Extract method for creating a filled file
- Remove BufReader
- Add benchmarks for store/restore
- Collapse if statements
- Fix new clippy warning
- Implement Send for cache Meta
- Make InMemoryStorage fully Send + Sync
- Remove no longer required RefCell from LocalCache
- Eliminate warning about unused variable
- Use thread-safe interior mutability for storage
- Remove unnecessary &mut from Storage::exists_file
- Simplify error constructor
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).