### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-10-29
+
+### Other
+
+- Make size_hint optional
+- Implement retrieval from remote cache
+- Implement simple HTTP/1.1 client
+- Implement simple HTTP/1.1 client
+
 ## 0.1.0 - 2025-03-01
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "tar",
  "tempfile",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -3129,6 +3130,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "btdt",
  "bytes 1.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "rkyv",
  "tar",
  "tempfile",
+ "url",
 ]
 
 [[package]]

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -16,7 +16,7 @@ name = "asyncio"
 path = "lib/asyncio.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt-server/benches/asyncio.rs
+++ b/btdt-server/benches/asyncio.rs
@@ -38,8 +38,10 @@ pub fn bench_stream_adapter(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Bytes(size as u64));
         group.bench_function(format!("Read {} KiB bytes", size_kB), |b| {
             b.to_async(&harness.runtime).iter(async || {
-                let mut stream_adapter =
-                    StreamAdapter::new(Box::new(File::open(&input_path).unwrap()), size as u64);
+                let mut stream_adapter = StreamAdapter::new(
+                    Box::new(File::open(&input_path).unwrap()),
+                    Some(size as u64),
+                );
                 while let Some(chunk) = stream_adapter.next().await {
                     black_box(chunk.unwrap());
                 }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -20,6 +20,7 @@ rkyv = "0.8.10"
 tar = "0.4.43"
 url = "2.5.7"
 fs2 = "0.4.3"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -18,6 +18,7 @@ data-encoding-macro = "0.1.16"
 rand = { version = "0.9.0", features = ["std_rng"] }
 rkyv = "0.8.10"
 tar = "0.4.43"
+url = "2.5.7"
 fs2 = "0.4.3"
 
 [dev-dependencies]

--- a/btdt/src/cache.rs
+++ b/btdt/src/cache.rs
@@ -49,5 +49,5 @@ pub struct CacheHit<'a, Reader: Read> {
     pub reader: Reader,
 
     /// (Approximate) size of the cached data in bytes.
-    pub size_hint: u64, // FIXME: should this be Option<u64>?
+    pub size_hint: Option<u64>,
 }

--- a/btdt/src/cache.rs
+++ b/btdt/src/cache.rs
@@ -49,5 +49,5 @@ pub struct CacheHit<'a, Reader: Read> {
     pub reader: Reader,
 
     /// (Approximate) size of the cached data in bytes.
-    pub size_hint: u64,
+    pub size_hint: u64, // FIXME: should this be Option<u64>?
 }

--- a/btdt/src/cache.rs
+++ b/btdt/src/cache.rs
@@ -9,6 +9,7 @@ use std::io::{Read, Write};
 pub mod blob_id;
 pub mod local;
 mod meta;
+mod remote;
 
 /// A cache manages keys and associated data.
 ///

--- a/btdt/src/cache/local.rs
+++ b/btdt/src/cache/local.rs
@@ -124,7 +124,7 @@ impl<S: Storage, C: Clock, R: RngBytes> Cache for LocalCache<S, C, R> {
                             return Ok(Some(CacheHit {
                                 key,
                                 reader: file_handle.reader,
-                                size_hint: file_handle.size_hint,
+                                size_hint: Some(file_handle.size_hint),
                             }));
                         }
                         Err(err) => match err.io_error().kind() {
@@ -541,7 +541,7 @@ mod tests {
             .read_to_string(&mut buf)
             .expect("failed to read cache entry");
         assert_eq!(buf, content, "cache entry content mismatch");
-        assert_eq!(size_hint, content.len() as u64);
+        assert_eq!(size_hint, Some(content.len() as u64));
     }
 
     fn assert_no_cache_entry<C: Cache>(cache: &C, keys: &[&str]) {

--- a/btdt/src/cache/remote.rs
+++ b/btdt/src/cache/remote.rs
@@ -1,0 +1,1 @@
+mod http;

--- a/btdt/src/cache/remote.rs
+++ b/btdt/src/cache/remote.rs
@@ -1,1 +1,240 @@
 mod http;
+
+use crate::cache::remote::http::{HttpClientError, HttpRequest, HttpResponse, ReadResponseBody};
+use crate::cache::{Cache, CacheHit};
+use crate::error::{IoPathError, IoPathResult, WithPath};
+use crate::util::close::Close;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
+use url::Url;
+
+pub struct RemoteCache {
+    base_url: Url,
+    cache_id: String,
+}
+
+impl RemoteCache {
+    pub fn new(base_url: &Url, cache_id: &str) -> Result<Self, RemoteCacheError> {
+        Ok(RemoteCache {
+            base_url: base_url
+                .join("api/caches/")
+                .expect("failed to join API path")
+                .join(cache_id)
+                .map_err(|err| RemoteCacheError::InvalidCacheId(cache_id.to_string(), err))?,
+            cache_id: cache_id.into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RemoteCacheError {
+    InvalidCacheId(String, url::ParseError),
+    HttpError { status: u16 },
+}
+
+impl Display for RemoteCacheError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCacheId(cache_id, _) => {
+                f.write_str("invalid cache ID: ")?;
+                f.write_str(cache_id)
+            }
+            Self::HttpError { status } => f.write_fmt(format_args!("http error: {status}")),
+        }
+    }
+}
+
+impl Error for RemoteCacheError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidCacheId(_, err) => Some(err),
+            Self::HttpError { .. } => None,
+        }
+    }
+}
+
+pub struct RemoteWriter;
+
+impl Write for RemoteWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        todo!()
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        todo!()
+    }
+}
+
+impl Close for RemoteWriter {
+    fn close(self) -> io::Result<()> {
+        todo!()
+    }
+}
+
+impl Cache for RemoteCache {
+    type Reader = HttpResponse<ReadResponseBody>;
+    type Writer = RemoteWriter;
+
+    fn get<'a>(&self, keys: &[&'a str]) -> IoPathResult<Option<CacheHit<'a, Self::Reader>>> {
+        if keys.len() < 1 {
+            return Ok(None);
+        }
+        let mut url = self.base_url.clone();
+        for key in keys {
+            url.query_pairs_mut().append_pair("key", key);
+        }
+        let try_request = || HttpRequest::get(&url)?.no_body()?.read_status();
+        let (status, mut response) = try_request()
+            .map_err(HttpClientError::into)
+            .with_path(url.as_str())?;
+
+        if !status.is_success() {
+            return Err(IoPathError::new_no_path(io::Error::other(
+                RemoteCacheError::HttpError {
+                    status: status.code_u16(),
+                },
+            )));
+        }
+
+        if status.code() == "204" {
+            return Ok(None);
+        }
+
+        let mut size_hint = None;
+        let mut hit_key = None;
+        while let Some(header) = response
+            .read_next_header()
+            .map_err(HttpClientError::into)
+            .with_path(url.as_str())?
+        {
+            if size_hint.is_none() && header.key().eq_ignore_ascii_case("content-length") {
+                size_hint = header.value().parse::<u64>().ok();
+            }
+            if hit_key.is_none() && header.key().eq_ignore_ascii_case("btdt-cache-key") {
+                hit_key = keys.iter().find(|&&key| key == header.value());
+            }
+            if size_hint.is_some() && hit_key.is_some() {
+                break;
+            }
+        }
+        let reader = response
+            .read_body()
+            .map_err(HttpClientError::into)
+            .with_path(url.as_str())?;
+
+        Ok(Some(CacheHit {
+            key: hit_key
+                .ok_or_else(|| {
+                    io::Error::new(
+                        ErrorKind::InvalidData,
+                        "missing Btdt-Cache-Key header in response",
+                    )
+                })
+                .with_path(url.as_str())?,
+            size_hint: size_hint.unwrap_or(0),
+            reader,
+        }))
+    }
+
+    fn set(&self, keys: &[&str]) -> IoPathResult<Self::Writer> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::http::tests::{EMPTY_RESPONSE, TestServer};
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn test_get_returns_none_for_empty_keys() {
+        let test_server = TestServer::start(EMPTY_RESPONSE.into()).unwrap();
+        let cache = RemoteCache::new(test_server.base_url(), "cache-id").unwrap();
+        assert!(cache.get(&[]).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_get_returns_non_for_cache_miss() -> io::Result<()> {
+        let test_server = TestServer::start(EMPTY_RESPONSE.into()).unwrap();
+        let addr = test_server.addr();
+        let cache = RemoteCache::new(test_server.base_url(), "cache-id").unwrap();
+        assert!(cache.get(&["non-existent"])?.is_none());
+
+        assert_eq!(
+            test_server.request()?,
+            format!(
+                "\
+                GET /api/caches/cache-id?key=non-existent HTTP/1.1\r\n\
+                Host: {}\r\n\
+                Connection: close\r\n\
+                User-Agent: btdt/{}\r\n\r\n\
+            ",
+                addr.ip(),
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_returns_data_for_cache_hit() -> io::Result<()> {
+        let test_server = TestServer::start(
+            "HTTP/1.1 200 Ok\r\nBtdt-Cache-Key: existent\r\nContent-Length: 8\r\n\r\nHello!\r\n"
+                .into(),
+        )
+        .unwrap();
+        let addr = test_server.addr();
+        let cache = RemoteCache::new(test_server.base_url(), "cache-id").unwrap();
+        let CacheHit {
+            key,
+            size_hint,
+            mut reader,
+        } = cache.get(&["non-existent", "existent"])?.unwrap();
+        assert_eq!(key, "existent");
+        assert_eq!(size_hint, 8);
+
+        let mut buf = String::new();
+        reader.read_to_string(&mut buf)?;
+        assert_eq!(buf, "Hello!\r\n");
+
+        assert_eq!(
+            test_server.request()?,
+            format!(
+                "\
+                GET /api/caches/cache-id?key=non-existent&key=existent HTTP/1.1\r\n\
+                Host: {}\r\n\
+                Connection: close\r\n\
+                User-Agent: btdt/{}\r\n\r\n\
+            ",
+                addr.ip(),
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_returns_error_for_non_success_http_status() -> io::Result<()> {
+        let test_server =
+            TestServer::start("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n".into())
+                .unwrap();
+        let cache = RemoteCache::new(test_server.base_url(), "cache-id").unwrap();
+        let error = cache.get(&["non-existent"]).err().unwrap().into_io_error();
+        assert_eq!(
+            error
+                .into_inner()
+                .unwrap()
+                .downcast::<RemoteCacheError>()
+                .unwrap(),
+            Box::new(RemoteCacheError::HttpError { status: 404 }),
+        );
+        Ok(())
+    }
+}

--- a/btdt/src/cache/remote.rs
+++ b/btdt/src/cache/remote.rs
@@ -135,7 +135,7 @@ impl Cache for RemoteCache {
                     )
                 })
                 .with_path(url.as_str())?,
-            size_hint: size_hint.unwrap_or(0),
+            size_hint,
             reader,
         }))
     }
@@ -197,7 +197,7 @@ mod tests {
             mut reader,
         } = cache.get(&["non-existent", "existent"])?.unwrap();
         assert_eq!(key, "existent");
-        assert_eq!(size_hint, 8);
+        assert_eq!(size_hint, Some(8));
 
         let mut buf = String::new();
         reader.read_to_string(&mut buf)?;

--- a/btdt/src/cache/remote/http.rs
+++ b/btdt/src/cache/remote/http.rs
@@ -1,0 +1,647 @@
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::io::{BufRead, BufReader, BufWriter, IntoInnerError, Read, Write};
+use std::marker::PhantomData;
+use std::net::TcpStream;
+use url::Url;
+
+const CRLF: &[u8] = b"\r\n";
+const HTTP_VERSION: &str = "HTTP/1.1";
+
+#[derive(Debug, Copy, Clone)]
+enum TransferEncodingType {
+    Chunked,
+    FixedSize(usize),
+}
+
+struct AwaitingRequestHeaders<T: OptionTransferEncoding> {
+    _transfer_encoding: PhantomData<T>,
+}
+struct AwaitingRequestBody<T: TransferEncoding> {
+    _transfer_encoding: PhantomData<T>,
+}
+struct ReadResponseStatus;
+struct ReadResponseHeaders;
+struct ReadResponseBody;
+
+trait State {}
+impl<T: OptionTransferEncoding> State for AwaitingRequestHeaders<T> {}
+impl<T: TransferEncoding> State for AwaitingRequestBody<T> {}
+impl State for ReadResponseStatus {}
+impl State for ReadResponseHeaders {}
+impl State for ReadResponseBody {}
+
+struct TNone;
+struct TSome<T> {
+    _type: PhantomData<T>,
+}
+
+trait OptionTransferEncoding {}
+impl OptionTransferEncoding for TNone {}
+impl<T: TransferEncoding> OptionTransferEncoding for TSome<T> {}
+
+struct NoBodyTransferEncoding;
+struct ChunkedTransferEncoding;
+struct FixedSizeTransferEncoding;
+
+trait TransferEncoding {}
+impl TransferEncoding for NoBodyTransferEncoding {}
+impl TransferEncoding for ChunkedTransferEncoding {}
+impl TransferEncoding for FixedSizeTransferEncoding {}
+
+pub struct HttpRequest<S: State> {
+    stream: BufWriter<TcpStream>,
+    _state: PhantomData<S>,
+}
+
+pub struct HttpResponse<S: State, R: Read = TcpStream> {
+    stream: BufReader<R>,
+    transfer_encoding: Option<TransferEncodingType>,
+    headers_exhausted: bool,
+    is_eof: bool,
+    chunk_bytes_remaining: usize,
+    _state: PhantomData<S>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpStatus {
+    status_line: String,
+}
+
+impl HttpStatus {
+    fn new(status_line: String) -> Result<HttpStatus> {
+        if !status_line.starts_with(HTTP_VERSION) {
+            return Err(HttpClientError::invalid_data("unsupported HTTP version"));
+        }
+        if status_line.as_bytes()[HTTP_VERSION.len()] != b' '
+            || status_line.as_bytes()[HTTP_VERSION.len() + 4] != b' '
+        {
+            return Err(HttpClientError::invalid_data("malformed status line"));
+        }
+        let status = Self { status_line };
+        if status.code().as_bytes().iter().any(|c| !c.is_ascii_digit()) {
+            return Err(HttpClientError::invalid_data("invalid HTTP status code"));
+        }
+        Ok(status)
+    }
+
+    pub fn code(&self) -> &str {
+        &self.status_line[HTTP_VERSION.len() + 1..HTTP_VERSION.len() + 4]
+    }
+
+    pub fn code_u16(&self) -> u16 {
+        self.code().parse().expect("invalid HTTP staus code")
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.code().as_bytes()[0] == b'2'
+    }
+
+    pub fn reason(&self) -> &str {
+        self.status_line[HTTP_VERSION.len() + 5..].trim_end()
+    }
+}
+
+#[derive(Debug)]
+pub enum HttpClientError {
+    InvalidScheme(String),
+    MissingHost,
+    UnsupportedFeature(&'static str),
+    IoError(io::Error),
+}
+
+impl HttpClientError {
+    pub fn invalid_data(msg: &str) -> Self {
+        HttpClientError::IoError(io::Error::new(io::ErrorKind::InvalidData, msg))
+    }
+}
+
+impl Display for HttpClientError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidScheme(scheme) => write!(f, "unknown URL scheme: {}", scheme),
+            Self::MissingHost => write!(f, "missing host"),
+            Self::UnsupportedFeature(feature) => write!(f, "unsupported feature: {}", feature),
+            Self::IoError(err) => write!(f, "I/O error: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for HttpClientError {}
+
+impl From<io::Error> for HttpClientError {
+    fn from(err: io::Error) -> Self {
+        HttpClientError::IoError(err)
+    }
+}
+
+type Result<T> = std::result::Result<T, HttpClientError>;
+
+impl HttpRequest<AwaitingRequestHeaders<TNone>> {
+    pub fn method(method: &str, url: &Url) -> Result<Self> {
+        let mut stream = Self::connect(url)?;
+        stream.write_all(method.as_bytes())?;
+        stream.write_all(b" ")?;
+        stream.write_all(url.path().as_bytes())?;
+        if let Some(query) = url.query() {
+            stream.write_all(b"?")?;
+            stream.write_all(query.as_bytes())?;
+        }
+        stream.write_all(b" ")?;
+        stream.write_all(HTTP_VERSION.as_bytes())?;
+        stream.write_all(CRLF)?;
+
+        let mut client = Self {
+            stream,
+            _state: PhantomData,
+        };
+
+        client.header("Host", url.host_str().ok_or(HttpClientError::MissingHost)?)?;
+        client.header("Connection", "close")?;
+        client.header("User-Agent", concat!("btdt/", env!("CARGO_PKG_VERSION")))?;
+
+        Ok(client)
+    }
+
+    pub fn get(
+        url: &Url,
+    ) -> Result<HttpRequest<AwaitingRequestHeaders<TSome<NoBodyTransferEncoding>>>> {
+        let client = Self::method("GET", url)?;
+        Ok(HttpRequest {
+            stream: client.stream,
+            _state: PhantomData,
+        })
+    }
+
+    pub fn post(url: &Url) -> Result<Self> {
+        Self::method("POST", url)
+    }
+
+    fn connect(url: &Url) -> Result<BufWriter<TcpStream>> {
+        let use_tls = match url.scheme() {
+            "http" => false,
+            "https" => true,
+            scheme => Err(HttpClientError::InvalidScheme(scheme.into()))?,
+        };
+        if use_tls {
+            todo!("TLS support not implemented");
+        }
+        if url.username() != "" || url.password().is_some() {
+            return Err(HttpClientError::UnsupportedFeature(
+                "username/password in URL",
+            ));
+        }
+        let port = url.port_or_known_default().expect("default port not known");
+        Ok(BufWriter::new(TcpStream::connect((
+            url.host_str().ok_or(HttpClientError::MissingHost)?,
+            port,
+        ))?))
+    }
+}
+
+impl<T: OptionTransferEncoding> HttpRequest<AwaitingRequestHeaders<T>> {
+    pub fn header(&mut self, key: &str, value: &str) -> Result<()> {
+        self.stream.write_all(key.as_bytes())?;
+        self.stream.write_all(b": ")?;
+        self.stream.write_all(value.as_bytes())?;
+        self.stream.write_all(CRLF)?;
+        Ok(())
+    }
+
+    pub fn no_body(mut self) -> Result<HttpResponse<ReadResponseStatus>> {
+        self.stream.write_all(CRLF)?;
+        Ok(HttpResponse {
+            stream: BufReader::new(
+                self.stream
+                    .into_inner()
+                    .map_err(IntoInnerError::into_error)?,
+            ),
+            transfer_encoding: None,
+            is_eof: false,
+            headers_exhausted: false,
+            chunk_bytes_remaining: 0,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl HttpRequest<AwaitingRequestHeaders<TNone>> {
+    pub fn body_with_size(
+        mut self,
+        size: usize,
+    ) -> Result<HttpRequest<AwaitingRequestBody<FixedSizeTransferEncoding>>> {
+        self.header("Content-Length", &size.to_string())?;
+        self.stream.write_all(CRLF)?;
+        Ok(HttpRequest {
+            stream: self.stream,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl Write for HttpRequest<AwaitingRequestBody<FixedSizeTransferEncoding>> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.stream.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+impl<T: TransferEncoding> HttpRequest<AwaitingRequestBody<T>> {
+    pub fn response(self) -> Result<HttpResponse<ReadResponseStatus>> {
+        Ok(HttpResponse {
+            stream: BufReader::new(
+                self.stream
+                    .into_inner()
+                    .map_err(IntoInnerError::into_error)?,
+            ),
+            transfer_encoding: None,
+            headers_exhausted: false,
+            is_eof: false,
+            chunk_bytes_remaining: 0,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl<S: State, R: Read> HttpResponse<S, R> {
+    pub fn into_inner_stream(self) -> BufReader<R> {
+        self.stream
+    }
+}
+
+impl HttpResponse<ReadResponseStatus> {
+    pub fn read_status(mut self) -> Result<(HttpStatus, HttpResponse<ReadResponseHeaders>)> {
+        let mut status_line = String::new();
+        self.stream.read_line(&mut status_line)?;
+        let status = HttpStatus::new(status_line.trim_end().to_string())?;
+
+        Ok((
+            status,
+            HttpResponse {
+                stream: self.stream,
+                transfer_encoding: self.transfer_encoding,
+                headers_exhausted: self.headers_exhausted,
+                is_eof: self.is_eof,
+                chunk_bytes_remaining: self.chunk_bytes_remaining,
+                _state: PhantomData,
+            },
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Header {
+    header_line: String,
+    key_end: usize,
+    value_start: usize,
+    value_end: usize,
+}
+
+impl Header {
+    fn new(header_line: String) -> Result<Header> {
+        let key_end = header_line.find(':').ok_or_else(|| {
+            HttpClientError::invalid_data("malformed header: missing colon separator")
+        })?;
+        let value_start = header_line[key_end + 1..]
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(0)
+            + key_end
+            + 1;
+        let value_end = header_line
+            .rfind(|c: char| !c.is_whitespace())
+            .map(|i| i + 1)
+            .unwrap_or(header_line.len())
+            .max(value_start);
+        Ok(Header {
+            header_line,
+            key_end,
+            value_start,
+            value_end,
+        })
+    }
+
+    pub fn key(&self) -> &str {
+        &self.header_line[..self.key_end]
+    }
+
+    pub fn value(&self) -> &str {
+        &self.header_line[self.value_start..self.value_end]
+    }
+}
+
+impl<R: Read> HttpResponse<ReadResponseHeaders, R> {
+    pub fn read_next_header(&mut self) -> Result<Option<Header>> {
+        if self.headers_exhausted {
+            return Ok(None);
+        }
+        let mut line = String::new();
+        self.stream.read_line(&mut line)?;
+        if line.trim().is_empty() {
+            self.headers_exhausted = true;
+            return Ok(None);
+        }
+        let header = Header::new(line)?;
+        if header.key().eq_ignore_ascii_case("Transfer-Encoding") {
+            if header.value().eq_ignore_ascii_case("chunked") {
+                self.transfer_encoding = Some(TransferEncodingType::Chunked);
+            } else {
+                return Err(HttpClientError::UnsupportedFeature("transfer encoding"));
+            }
+        } else if header.key().eq_ignore_ascii_case("Content-Length") {
+            let size: usize = header.value().parse().map_err(|_| {
+                HttpClientError::invalid_data("invalid Content-Length header value")
+            })?;
+            self.transfer_encoding = Some(TransferEncodingType::FixedSize(size));
+        }
+        Ok(Some(header))
+    }
+
+    pub fn read_body(mut self) -> Result<HttpResponse<ReadResponseBody, R>> {
+        while !self.headers_exhausted {
+            self.read_next_header()?;
+        }
+        Ok(HttpResponse {
+            stream: self.stream,
+            transfer_encoding: self.transfer_encoding,
+            headers_exhausted: true,
+            is_eof: false,
+            chunk_bytes_remaining: match self.transfer_encoding {
+                None => 0,
+                Some(TransferEncodingType::Chunked) => 0,
+                Some(TransferEncodingType::FixedSize(size)) => size,
+            },
+            _state: PhantomData,
+        })
+    }
+}
+
+impl<R: Read> Iterator for HttpResponse<ReadResponseHeaders, R> {
+    type Item = Result<Header>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.read_next_header() {
+            Ok(None) => None,
+            Ok(Some(header)) => Some(Ok(header)),
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+impl<R: Read> Read for HttpResponse<ReadResponseBody, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.is_eof {
+            return Ok(0);
+        }
+        match self.transfer_encoding {
+            None => {
+                self.is_eof = true;
+                Ok(0)
+            }
+            Some(TransferEncodingType::FixedSize(_)) => {
+                let max_n = buf.len().min(self.chunk_bytes_remaining);
+                self.stream.read(buf[..max_n].as_mut()).inspect(|n| {
+                    self.chunk_bytes_remaining -= n;
+                    if self.chunk_bytes_remaining == 0 {
+                        self.is_eof = true;
+                    }
+                })
+            }
+            Some(TransferEncodingType::Chunked) => {
+                if self.chunk_bytes_remaining == 0 {
+                    let mut octets = String::new();
+                    self.stream.read_line(&mut octets)?;
+                    self.chunk_bytes_remaining =
+                        usize::from_str_radix(octets.trim(), 16).map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("invalid chunk size: {}", octets.trim()),
+                            )
+                        })?;
+                    if self.chunk_bytes_remaining == 0 {
+                        self.stream.read([0; 2].as_mut())?; // trailing CRLF
+                        self.is_eof = true;
+                        return Ok(0);
+                    }
+                }
+                let max_n = buf.len().min(self.chunk_bytes_remaining);
+                let n = self.stream.read(&mut buf[..max_n]).inspect(|n| {
+                    self.chunk_bytes_remaining -= n;
+                })?;
+                self.stream.read_exact([0; 2].as_mut())?; // trailing CRLF
+                Ok(n)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{SocketAddr, TcpListener};
+    use std::thread;
+    use std::thread::JoinHandle;
+
+    const EMPTY_RESPONSE: &str = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+
+    struct TestServer {
+        join_handle: JoinHandle<io::Result<String>>,
+        addr: SocketAddr,
+    }
+
+    impl TestServer {
+        pub fn start(response: String) -> io::Result<Self> {
+            let listener = TcpListener::bind("127.0.0.1:0")?;
+            let addr = listener.local_addr()?;
+            let join_handle = thread::spawn(move || Self::serve_once(listener, &response));
+            Ok(Self { join_handle, addr })
+        }
+
+        fn serve_once(listener: TcpListener, response: &str) -> io::Result<String> {
+            let (mut stream, _) = listener.accept()?;
+            let mut stream = BufReader::new(&mut stream);
+
+            let mut request_line = String::new();
+            stream.read_line(&mut request_line)?;
+            let mut lines: Vec<String> = vec![request_line];
+            let mut reader: HttpResponse<ReadResponseHeaders, _> = HttpResponse {
+                stream,
+                transfer_encoding: None,
+                headers_exhausted: false,
+                is_eof: false,
+                chunk_bytes_remaining: 0,
+                _state: Default::default(),
+            };
+            while let Some(header) = reader
+                .read_next_header()
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+            {
+                lines.push(header.header_line);
+            }
+            lines.push("\r\n".into());
+            let mut body_reader = reader
+                .read_body()
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            let mut body = String::new();
+            body_reader.read_to_string(&mut body)?;
+            lines.push(body);
+
+            let stream = body_reader.into_inner_stream().into_inner();
+            stream.write_all(response.as_bytes())?;
+            Ok(lines.join(""))
+        }
+
+        pub fn request(self) -> io::Result<String> {
+            self.join_handle.join().unwrap()
+        }
+
+        pub fn addr(&self) -> SocketAddr {
+            self.addr
+        }
+    }
+
+    #[test]
+    fn test_get_request_without_body() -> Result<()> {
+        let test_server = TestServer::start(EMPTY_RESPONSE.into())?;
+        let addr = test_server.addr();
+        let url = Url::parse(&format!(
+            "http://{}:{}/path?query=foo#fragment",
+            addr.ip().to_string(),
+            addr.port()
+        ))
+        .unwrap();
+        let response = HttpRequest::get(&url)?.no_body()?;
+
+        assert_eq!(
+            test_server.request()?,
+            format!(
+                "GET /path?query=foo HTTP/1.1\r\n\
+                Host: {}\r\n\
+                Connection: close\r\n\
+                User-Agent: btdt/{}\r\n\r\n",
+                addr.ip(),
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+
+        let (status, mut response) = response.read_status()?;
+        assert_eq!(
+            status,
+            HttpStatus::new("HTTP/1.1 204 No Content".to_string())?
+        );
+        assert_eq!(
+            response.read_next_header()?,
+            Some(Header::new("Content-Length: 0\r\n".to_string())?)
+        );
+        assert_eq!(response.read_next_header()?, None);
+        let mut buf = String::new();
+        response.read_body().unwrap().read_to_string(&mut buf)?;
+        assert!(buf.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_post_with_fixed_size_body() -> Result<()> {
+        let test_server = TestServer::start(EMPTY_RESPONSE.into())?;
+        let addr = test_server.addr();
+        let url = Url::parse(&format!(
+            "http://{}:{}/path?query=foo#fragment",
+            addr.ip().to_string(),
+            addr.port()
+        ))
+        .unwrap();
+        let body = "{\"hello\": \"world\"}\r\n";
+        let mut request = HttpRequest::post(&url)?.body_with_size(body.len())?;
+        request.write_all(body.as_bytes())?;
+        let response = request.response()?;
+
+        assert_eq!(
+            test_server.request()?,
+            format!(
+                "POST /path?query=foo HTTP/1.1\r\n\
+                Host: {}\r\n\
+                Connection: close\r\n\
+                User-Agent: btdt/{}\r\n\
+                Content-Length: {}\r\n\r\n\
+                {}",
+                addr.ip(),
+                env!("CARGO_PKG_VERSION"),
+                body.len(),
+                body
+            )
+        );
+
+        let (status, mut response) = response.read_status()?;
+        assert_eq!(
+            status,
+            HttpStatus::new("HTTP/1.1 204 No Content".to_string())?
+        );
+        assert_eq!(
+            response.read_next_header()?,
+            Some(Header::new("Content-Length: 0\r\n".to_string())?)
+        );
+        assert_eq!(response.read_next_header()?, None);
+        let mut buf = String::new();
+        response.read_body().unwrap().read_to_string(&mut buf)?;
+        assert!(buf.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_body_with_content_length() -> Result<()> {
+        let test_server = TestServer::start(
+            "\
+            HTTP/1.1 200 OK\r\n\
+            Content-Length: 8\r\n\
+            \r\n\
+            Hello!\r\n"
+                .into(),
+        )?;
+        let addr = test_server.addr();
+        let url = Url::parse(&format!(
+            "http://{}:{}/path?query=foo#fragment",
+            addr.ip().to_string(),
+            addr.port()
+        ))
+        .unwrap();
+        let response = HttpRequest::get(&url)?.no_body()?;
+
+        let (status, response) = response.read_status()?;
+        assert_eq!(status, HttpStatus::new("HTTP/1.1 200 OK".to_string())?);
+        let mut buf = String::new();
+        response.read_body().unwrap().read_to_string(&mut buf)?;
+        assert_eq!(&buf, "Hello!\r\n");
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_body_with_chunked_transfer_encoding() -> Result<()> {
+        let test_server = TestServer::start(
+            "\
+            HTTP/1.1 200 OK\r\n\
+            Transfer-Encoding: chunked\r\n\
+            \r\n\
+            a\r\nHello, wor\r\n\
+            5\r\nld!\r\n\r\n\
+            0\r\n\r\n"
+                .into(),
+        )?;
+        let addr = test_server.addr();
+        let url = Url::parse(&format!(
+            "http://{}:{}/path?query=foo#fragment",
+            addr.ip().to_string(),
+            addr.port()
+        ))
+        .unwrap();
+        let response = HttpRequest::get(&url)?.no_body()?;
+
+        let (status, response) = response.read_status()?;
+        assert_eq!(status, HttpStatus::new("HTTP/1.1 200 OK".to_string())?);
+        let mut buf = String::new();
+        response.read_body().unwrap().read_to_string(&mut buf)?;
+        assert_eq!(&buf, "Hello, world!\r\n");
+        Ok(())
+    }
+}

--- a/btdt/src/cache/remote/http.rs
+++ b/btdt/src/cache/remote/http.rs
@@ -14,6 +14,7 @@ enum TransferEncodingType {
     FixedSize(usize),
 }
 
+trait State {}
 struct AwaitingRequestHeaders<T: OptionTransferEncoding> {
     _transfer_encoding: PhantomData<T>,
 }
@@ -23,31 +24,27 @@ struct AwaitingRequestBody<T: TransferEncoding> {
 struct ReadResponseStatus;
 struct ReadResponseHeaders;
 struct ReadResponseBody;
-
-trait State {}
 impl<T: OptionTransferEncoding> State for AwaitingRequestHeaders<T> {}
 impl<T: TransferEncoding> State for AwaitingRequestBody<T> {}
 impl State for ReadResponseStatus {}
 impl State for ReadResponseHeaders {}
 impl State for ReadResponseBody {}
 
+trait TransferEncoding {}
+struct NoBodyTransferEncoding;
+struct ChunkedTransferEncoding;
+struct FixedSizeTransferEncoding;
+impl TransferEncoding for NoBodyTransferEncoding {}
+impl TransferEncoding for ChunkedTransferEncoding {}
+impl TransferEncoding for FixedSizeTransferEncoding {}
+
+trait OptionTransferEncoding {}
 struct TNone;
 struct TSome<T> {
     _type: PhantomData<T>,
 }
-
-trait OptionTransferEncoding {}
 impl OptionTransferEncoding for TNone {}
 impl<T: TransferEncoding> OptionTransferEncoding for TSome<T> {}
-
-struct NoBodyTransferEncoding;
-struct ChunkedTransferEncoding;
-struct FixedSizeTransferEncoding;
-
-trait TransferEncoding {}
-impl TransferEncoding for NoBodyTransferEncoding {}
-impl TransferEncoding for ChunkedTransferEncoding {}
-impl TransferEncoding for FixedSizeTransferEncoding {}
 
 pub struct HttpRequest<S: State> {
     stream: BufWriter<TcpStream>,

--- a/btdt/src/cache/remote/http.rs
+++ b/btdt/src/cache/remote/http.rs
@@ -15,15 +15,15 @@ enum TransferEncodingType {
 }
 
 trait State {}
-struct AwaitingRequestHeaders<T: OptionTransferEncoding> {
+pub struct AwaitingRequestHeaders<T: OptionTransferEncoding> {
     _transfer_encoding: PhantomData<T>,
 }
-struct AwaitingRequestBody<T: TransferEncoding> {
+pub struct AwaitingRequestBody<T: TransferEncoding> {
     _transfer_encoding: PhantomData<T>,
 }
-struct ReadResponseStatus;
-struct ReadResponseHeaders;
-struct ReadResponseBody;
+pub struct ReadResponseStatus;
+pub struct ReadResponseHeaders;
+pub struct ReadResponseBody;
 impl<T: OptionTransferEncoding> State for AwaitingRequestHeaders<T> {}
 impl<T: TransferEncoding> State for AwaitingRequestBody<T> {}
 impl State for ReadResponseStatus {}
@@ -31,16 +31,16 @@ impl State for ReadResponseHeaders {}
 impl State for ReadResponseBody {}
 
 trait TransferEncoding {}
-struct NoBodyTransferEncoding;
-struct ChunkedTransferEncoding;
-struct FixedSizeTransferEncoding;
+pub struct NoBodyTransferEncoding;
+pub struct ChunkedTransferEncoding;
+pub struct FixedSizeTransferEncoding;
 impl TransferEncoding for NoBodyTransferEncoding {}
 impl TransferEncoding for ChunkedTransferEncoding {}
 impl TransferEncoding for FixedSizeTransferEncoding {}
 
 trait OptionTransferEncoding {}
-struct TNone;
-struct TSome<T> {
+pub struct TNone;
+pub struct TSome<T> {
     _type: PhantomData<T>,
 }
 impl OptionTransferEncoding for TNone {}
@@ -129,6 +129,19 @@ impl std::error::Error for HttpClientError {}
 impl From<io::Error> for HttpClientError {
     fn from(err: io::Error) -> Self {
         HttpClientError::IoError(err)
+    }
+}
+
+impl Into<io::Error> for HttpClientError {
+    fn into(self) -> io::Error {
+        match self {
+            HttpClientError::InvalidScheme(_) => io::Error::new(io::ErrorKind::InvalidInput, self),
+            HttpClientError::MissingHost => io::Error::new(io::ErrorKind::InvalidInput, self),
+            HttpClientError::UnsupportedFeature(_) => {
+                io::Error::new(io::ErrorKind::Unsupported, self)
+            }
+            HttpClientError::IoError(err) => err,
+        }
     }
 }
 
@@ -290,7 +303,7 @@ impl HttpResponse<ReadResponseStatus> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct Header {
+pub struct Header {
     header_line: String,
     key_end: usize,
     value_start: usize,
@@ -435,25 +448,32 @@ impl<R: Read> Read for HttpResponse<ReadResponseBody, R> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use std::net::{SocketAddr, TcpListener};
     use std::thread;
     use std::thread::JoinHandle;
 
-    const EMPTY_RESPONSE: &str = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+    pub const EMPTY_RESPONSE: &str = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
 
-    struct TestServer {
+    pub struct TestServer {
         join_handle: JoinHandle<io::Result<String>>,
         addr: SocketAddr,
+        base_url: Url,
     }
 
     impl TestServer {
         pub fn start(response: String) -> io::Result<Self> {
             let listener = TcpListener::bind("127.0.0.1:0")?;
             let addr = listener.local_addr()?;
+            let base_url =
+                Url::parse(&format!("http://{}:{}", addr.ip().to_string(), addr.port())).unwrap();
             let join_handle = thread::spawn(move || Self::serve_once(listener, &response));
-            Ok(Self { join_handle, addr })
+            Ok(Self {
+                join_handle,
+                addr,
+                base_url,
+            })
         }
 
         fn serve_once(listener: TcpListener, response: &str) -> io::Result<String> {
@@ -496,6 +516,10 @@ mod tests {
 
         pub fn addr(&self) -> SocketAddr {
             self.addr
+        }
+
+        pub fn base_url(&self) -> &Url {
+            &self.base_url
         }
     }
 
@@ -543,12 +567,9 @@ mod tests {
     fn test_post_with_fixed_size_body() -> Result<()> {
         let test_server = TestServer::start(EMPTY_RESPONSE.into())?;
         let addr = test_server.addr();
-        let url = Url::parse(&format!(
-            "http://{}:{}/path?query=foo#fragment",
-            addr.ip().to_string(),
-            addr.port()
-        ))
-        .unwrap();
+        let mut url = test_server.base_url().join("path").unwrap();
+        url.query_pairs_mut().append_pair("query", "foo");
+        url.set_fragment(Some("fragment"));
         let body = "{\"hello\": \"world\"}\r\n";
         let mut request = HttpRequest::post(&url)?.body_with_size(body.len())?;
         request.write_all(body.as_bytes())?;
@@ -597,12 +618,9 @@ mod tests {
                 .into(),
         )?;
         let addr = test_server.addr();
-        let url = Url::parse(&format!(
-            "http://{}:{}/path?query=foo#fragment",
-            addr.ip().to_string(),
-            addr.port()
-        ))
-        .unwrap();
+        let mut url = test_server.base_url().join("path").unwrap();
+        url.query_pairs_mut().append_pair("query", "foo");
+        url.set_fragment(Some("fragment"));
         let response = HttpRequest::get(&url)?.no_body()?;
 
         let (status, response) = response.read_status()?;
@@ -626,12 +644,9 @@ mod tests {
                 .into(),
         )?;
         let addr = test_server.addr();
-        let url = Url::parse(&format!(
-            "http://{}:{}/path?query=foo#fragment",
-            addr.ip().to_string(),
-            addr.port()
-        ))
-        .unwrap();
+        let mut url = test_server.base_url().join("path").unwrap();
+        url.query_pairs_mut().append_pair("query", "foo");
+        url.set_fragment(Some("fragment"));
         let response = HttpRequest::get(&url)?.no_body()?;
 
         let (status, response) = response.read_status()?;


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `btdt-cli`: 0.2.0 -> 0.2.1
* `btdt-server`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-10-29

### Other

- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>

## `btdt-server`

<blockquote>

## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-10-29

### Other

- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).