### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-02
+
+### Other
+
+- Address compiler warnings and clippy lints
+- Implement TLS support
+- Remove unused dependency
+- Implement integration test for remote cache and cache server
+- Implement setting cache entries with remote cache
+- Implement sending with chunked transfer encoding in HTTP client
+- Make size_hint optional
+- Implement retrieval from remote cache
+- Implement simple HTTP/1.1 client
+- Implement simple HTTP/1.1 client
+
 ## 0.1.0 - 2025-03-01
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "btdt",
  "bytes 1.10.1",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -16,7 +16,7 @@ name = "asyncio"
 path = "lib/asyncio.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt-server/tests/test_server/mod.rs
+++ b/btdt-server/tests/test_server/mod.rs
@@ -5,12 +5,14 @@ use std::fmt::{Display, Formatter};
 use std::fs;
 use std::process::{Child, Command};
 use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
 
 #[allow(unused)]
 pub static CERTIFICATE_PKCS12: &[u8] = include_bytes!("../../../tls/leaf.p12");
 pub static CERTIFICATE_PEM: &[u8] = include_bytes!("../../../tls/ca.pem");
 
 pub struct BtdtTestServer {
+    config_file: NamedTempFile,
     process: Child,
     client: Client,
     base_url: Url,
@@ -44,6 +46,7 @@ impl BtdtTestServer {
         let process = command.spawn().expect("failed to start btdt-server");
         let tls_enabled = env.contains_key("BTDT_TLS_KEYSTORE");
         Self {
+            config_file,
             process,
             client: Client::builder()
                 .add_root_certificate(Certificate::from_pem(CERTIFICATE_PEM).unwrap())

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `btdt-cli`: 0.2.0 -> 0.2.1
* `btdt-server`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-02

### Other

- Address compiler warnings and clippy lints
- Implement TLS support
- Remove unused dependency
- Implement integration test for remote cache and cache server
- Implement setting cache entries with remote cache
- Implement sending with chunked transfer encoding in HTTP client
- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>

## `btdt-server`

<blockquote>

## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-02

### Other

- Address compiler warnings and clippy lints
- Implement TLS support
- Remove unused dependency
- Implement integration test for remote cache and cache server
- Implement setting cache entries with remote cache
- Implement sending with chunked transfer encoding in HTTP client
- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).