### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-16
+
+### Other
+
+- Address clippy warning about enum size difference
+- Fix dead code warnings
+- Implement authorization
+- Support remote cache in CLI
+- Replace enum dispatch with `Box<dyn ...>`
+- Allow to set TLS configuration from outside RemoteCache
+- Address compiler warnings and clippy lints
+- Implement TLS support
+- Remove unused dependency
+- Implement integration test for remote cache and cache server
+- Implement setting cache entries with remote cache
+- Implement sending with chunked transfer encoding in HTTP client
+- Make size_hint optional
+- Implement retrieval from remote cache
+- Implement simple HTTP/1.1 client
+- Implement simple HTTP/1.1 client
+
 ## 0.1.0 - 2025-03-01
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-16
+## [0.3.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.3.0) - 2025-11-16
 
 ### Other
 
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement sending with chunked transfer encoding in HTTP client
 - Make size_hint optional
 - Implement retrieval from remote cache
-- Implement simple HTTP/1.1 client
 - Implement simple HTTP/1.1 client
 
 ## 0.1.0 - 2025-03-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"
@@ -28,7 +28,7 @@ url = "2.5.7"
 biscuit-auth = "6.0.0"
 
 [dev-dependencies]
-btdt-server = { path = "../btdt-server", version = "0.2.0", features = ["test"] }
+btdt-server = { path = "../btdt-server", version = "0.2.1", features = ["test"] }
 rand = { version = "0.9.0", features = ["std_rng"] }
 tempfile = "3.15.0"
 trycmd = "0.15.8"

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.2.1" }
+btdt = { path = "../btdt", version = "0.3.0" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"
@@ -28,7 +28,7 @@ url = "2.5.7"
 biscuit-auth = "6.0.0"
 
 [dev-dependencies]
-btdt-server = { path = "../btdt-server", version = "0.2.1", features = ["test"] }
+btdt-server = { path = "../btdt-server", version = "0.3.0", features = ["test"] }
 rand = { version = "0.9.0", features = ["std_rng"] }
 tempfile = "3.15.0"
 trycmd = "0.15.8"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.2.0" }
+btdt = { path = "../btdt", version = "0.2.1" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.2.1" }
+btdt = { path = "../btdt", version = "0.3.0" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION


## 🤖 New release

* `btdt`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `btdt-cli`: 0.2.0 -> 0.3.0
* `btdt-server`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.3.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.3.0) - 2025-11-16

### Other

- Address clippy warning about enum size difference
- Fix dead code warnings
- Implement authorization
- Support remote cache in CLI
- Replace enum dispatch with `Box<dyn ...>`
- Allow to set TLS configuration from outside RemoteCache
- Address compiler warnings and clippy lints
- Implement TLS support
- Remove unused dependency
- Implement integration test for remote cache and cache server
- Implement setting cache entries with remote cache
- Implement sending with chunked transfer encoding in HTTP client
- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>

## `btdt-server`

<blockquote>

## [0.2.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.2.1) - 2025-11-16

### Other

- Address clippy warning about enum size difference
- Fix dead code warnings
- Implement authorization
- Support remote cache in CLI
- Replace enum dispatch with `Box<dyn ...>`
- Allow to set TLS configuration from outside RemoteCache
- Address compiler warnings and clippy lints
- Implement TLS support
- Remove unused dependency
- Implement integration test for remote cache and cache server
- Implement setting cache entries with remote cache
- Implement sending with chunked transfer encoding in HTTP client
- Make size_hint optional
- Implement retrieval from remote cache
- Implement simple HTTP/1.1 client
- Implement simple HTTP/1.1 client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).