### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.0...btdt-cli-v0.3.1) - 2025-11-18
+
+### Other
+
+- Bump versions
+
 ## [0.3.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.2.0...btdt-cli-v0.3.0) - 2025-11-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"


### PR DESCRIPTION



## 🤖 New release

* `btdt-cli`: 0.3.0 -> 0.3.1
* `btdt-server`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `btdt-cli`

<blockquote>

## [0.3.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.0...btdt-cli-v0.3.1) - 2025-11-18

### Other

- Bump versions
</blockquote>

## `btdt-server`

<blockquote>

## [0.3.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.0...btdt-cli-v0.3.1) - 2025-11-18

### Other

- Bump versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).