### PR TITLE
chore: release v0.3.3

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -24,6 +24,7 @@ defaults:
 
 jobs:
   upload-assets:
+    if: endsWith('-musl', matrix.target) && !contains(inputs.version || github.even.release.tag_name, 'btdt-server')
     permissions:
       contents: write
     strategy:
@@ -55,11 +56,6 @@ jobs:
           echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
           echo "binary_name=${COMPONENT/btdt-cli/btdt}" >> $GITHUB_OUTPUT
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-      - name: Install OpenSSL (Linux only)
-        if: matrix.os != 'macos-latest'
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.target }}
       - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-server-v0.3.2...btdt-server-v0.3.3) - 2025-11-23
+
+### Fixed
+
+- Implement graceful btdt-server shutdown
+
+### Other
+
+- Install libssl-dev to fix build of server binaries
+
 ## [0.3.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.1...btdt-cli-v0.3.2) - 2025-11-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.3.2" }
+btdt = { path = "../btdt", version = "0.3.3" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.3.2" }
+btdt = { path = "../btdt", version = "0.3.3" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.3.2 -> 0.3.3
* `btdt-cli`: 0.3.2 -> 0.3.3
* `btdt-server`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.3.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.1...btdt-cli-v0.3.2) - 2025-11-18

### Other

- Bump version
</blockquote>

## `btdt-server`

<blockquote>

## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-server-v0.3.2...btdt-server-v0.3.3) - 2025-11-23

### Fixed

- Implement graceful btdt-server shutdown

### Other

- Install libssl-dev to fix build of server binaries
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).