### PR TITLE
chore: release v0.3.3

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -55,6 +55,9 @@ jobs:
           echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
           echo "binary_name=${COMPONENT/btdt-cli/btdt}" >> $GITHUB_OUTPUT
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+      - name: Install OpenSSL (Linux only)
+        if: matrix.os != 'macos-latest'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
       - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
@@ -62,3 +65,4 @@ jobs:
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: refs/tags/${{ steps.version-info.outputs.tag }}
+          build-tool: cargo

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Install OpenSSL (Linux only)
         if: matrix.os != 'macos-latest'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
       - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -33,12 +33,14 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            skip-for: [btdt-server]
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            skip-for: [btdt-server]
           - target: aarch64-apple-darwin
             os: macos-latest
     runs-on: ${{ matrix.os }}
@@ -55,13 +57,13 @@ jobs:
           echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
           echo "binary_name=${COMPONENT/btdt-cli/btdt}" >> $GITHUB_OUTPUT
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-      - name: Install OpenSSL (Linux only)
-        if: matrix.os != 'macos-latest'
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
-      - name: Install Rust target
+      - name: Install toolchain for target
         run: rustup target add ${{ matrix.target }}
+        if: ${{ !contains(matrix.skip-for, steps.version-info.outputs.component) }}
       - uses: actions/checkout@v4
+        if: ${{ !contains(matrix.skip-for, steps.version-info.outputs.component) }}
       - uses: taiki-e/upload-rust-binary-action@v1
+        if: ${{ !contains(matrix.skip-for, steps.version-info.outputs.component) }}
         with:
           bin: ${{ steps.version-info.outputs.binary_name }}
           target: ${{ matrix.target }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -35,11 +35,11 @@ jobs:
             os: ubuntu-latest
             skip-for: [btdt-server]
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             skip-for: [btdt-server]
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -57,9 +57,6 @@ jobs:
           echo "component=${COMPONENT}" >> $GITHUB_OUTPUT
           echo "binary_name=${COMPONENT/btdt-cli/btdt}" >> $GITHUB_OUTPUT
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-      - name: Install toolchain for target
-        run: rustup target add ${{ matrix.target }}
-        if: ${{ !contains(matrix.skip-for, steps.version-info.outputs.component) }}
       - uses: actions/checkout@v4
         if: ${{ !contains(matrix.skip-for, steps.version-info.outputs.component) }}
       - uses: taiki-e/upload-rust-binary-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-server-v0.3.2...btdt-server-v0.3.3) - 2025-11-23
+
+### Fixed
+
+- Implement graceful btdt-server shutdown
+
+### Other
+
+- Install libssl-dev to fix build of server binaries
+
 ## [0.3.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.1...btdt-cli-v0.3.2) - 2025-11-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "criterion",
  "data-encoding",
  "futures-core",
+ "humantime",
  "poem",
  "poem-openapi",
  "rand_core 0.9.3",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.3.2" }
+btdt = { path = "../btdt", version = "0.3.3" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.3.2" }
+btdt = { path = "../btdt", version = "0.3.3" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -23,6 +23,7 @@ btdt = { path = "../btdt", version = "0.3.2" }
 bytes = "1.10.1"
 config = { version = "0.15.13", features = ["toml"] }
 futures-core = "0.3.31"
+humantime = "2.1.0"
 poem = { version = "3", features = ["native-tls"] }
 poem-openapi = { version = "5", features = ["swagger-ui"] }
 serde = "1.0.219"

--- a/btdt-server/src/app.rs
+++ b/btdt-server/src/app.rs
@@ -1,5 +1,6 @@
 use crate::config::CacheConfig;
 use biscuit_auth::KeyPair;
+use btdt::cache::cache_dispatcher::CacheDispatcher;
 use poem::Route;
 use std::collections::HashMap;
 
@@ -43,12 +44,11 @@ impl OptionsBuilder {
 
 pub fn create_route(
     options: Options,
-    cache_config: &HashMap<String, CacheConfig>,
+    caches: HashMap<String, CacheDispatcher>,
     auth_key_pair: KeyPair,
 ) -> Route {
     const API_PREFIX: &str = "/api";
-    let api_service =
-        api::create_openapi_service(cache_config, auth_key_pair).url_prefix(API_PREFIX);
+    let api_service = api::create_openapi_service(caches, auth_key_pair).url_prefix(API_PREFIX);
     let mut route = Route::new();
     if options.enable_api_docs {
         let docs = api_service.swagger_ui();

--- a/btdt-server/src/app/api.rs
+++ b/btdt-server/src/app/api.rs
@@ -25,25 +25,9 @@ pub struct Api {
 }
 
 pub fn create_openapi_service(
-    config: &HashMap<String, CacheConfig>,
+    caches: HashMap<String, CacheDispatcher>,
     auth_key_pair: KeyPair,
 ) -> OpenApiService<Api, ()> {
-    let caches = config
-        .iter()
-        .map(|(key, cache_config)| {
-            (
-                key.clone(),
-                match cache_config {
-                    CacheConfig::InMemory => {
-                        CacheDispatcher::InMemory(LocalCache::new(InMemoryStorage::new()))
-                    }
-                    CacheConfig::Filesystem { path } => CacheDispatcher::Filesystem(
-                        LocalCache::new(FilesystemStorage::new(path.into())),
-                    ),
-                },
-            )
-        })
-        .collect();
     OpenApiService::new(
         Api {
             caches,

--- a/btdt-server/tests/integration.rs
+++ b/btdt-server/tests/integration.rs
@@ -10,7 +10,79 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
 use tempfile::tempdir;
+
+struct BtdtTestServerWithAuthorizedClient {
+    key_dir: tempfile::TempDir,
+    server: BtdtTestServer,
+    client: Pipeline<RemoteCache>,
+}
+
+impl Default for BtdtTestServerWithAuthorizedClient {
+    fn default() -> Self {
+        Self::new(BTreeMap::new())
+    }
+}
+
+impl BtdtTestServerWithAuthorizedClient {
+    fn new(mut env: BTreeMap<String, String>) -> Self {
+        let key_dir = tempdir().unwrap();
+        let key_path = key_dir.path().join("private_key.pem");
+        let key_pair = KeyPair::new();
+        let mut keyfile = OpenOptions::new()
+            .mode(0o600)
+            .create_new(true)
+            .write(true)
+            .open(&key_path)
+            .unwrap();
+        keyfile
+            .write_all(key_pair.to_private_key_pem().unwrap().as_bytes())
+            .unwrap();
+        let token =
+            UnverifiedBiscuit::from(&biscuit!("").build(&key_pair).unwrap().to_vec().unwrap())
+                .unwrap();
+
+        env.insert(
+            "BTDT_AUTH_PRIVATE_KEY".into(),
+            key_path.to_str().unwrap().to_string(),
+        );
+        let server = BtdtTestServer::new(&env).wait_until_ready().unwrap();
+
+        let client = Pipeline::new(
+            RemoteCache::new(
+                server.base_url(),
+                "test-cache",
+                HttpClient::default().unwrap(),
+                token,
+            )
+            .unwrap(),
+        );
+
+        Self {
+            client,
+            key_dir,
+            server,
+        }
+    }
+}
+
+struct TestData {
+    tempdir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl Default for TestData {
+    fn default() -> Self {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("source-root");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("file.txt"), "Hello, world!").unwrap();
+        Self { tempdir, path }
+    }
+}
 
 #[test]
 #[serial]
@@ -27,44 +99,13 @@ fn test_health_endpoint() {
 #[test]
 #[serial]
 fn test_roundtrip() {
-    let key_dir = tempdir().unwrap();
-    let key_path = key_dir.path().join("private_key.pem");
-    let key_pair = KeyPair::new();
-    let mut keyfile = OpenOptions::new()
-        .mode(0o600)
-        .create_new(true)
-        .write(true)
-        .open(&key_path)
-        .unwrap();
-    keyfile
-        .write_all(key_pair.to_private_key_pem().unwrap().as_bytes())
-        .unwrap();
-    let token =
-        UnverifiedBiscuit::from(&biscuit!("").build(&key_pair).unwrap().to_vec().unwrap()).unwrap();
+    let server_with_client = BtdtTestServerWithAuthorizedClient::default();
+    let mut client = server_with_client.client;
+    let test_data = TestData::default();
 
-    let server = BtdtTestServer::new(&BTreeMap::from([(
-        "BTDT_AUTH_PRIVATE_KEY".into(),
-        key_path.to_str().unwrap().to_string(),
-    )]))
-    .wait_until_ready()
-    .unwrap();
-    let mut client = Pipeline::new(
-        RemoteCache::new(
-            server.base_url(),
-            "test-cache",
-            HttpClient::default().unwrap(),
-            token,
-        )
-        .unwrap(),
-    );
+    client.store(&["key1", "key2"], &test_data.path).unwrap();
 
     let tempdir = tempdir().unwrap();
-    let source_path = tempdir.path().join("source-root");
-    fs::create_dir(&source_path).unwrap();
-    fs::write(source_path.join("file.txt"), "Hello, world!").unwrap();
-
-    client.store(&["key1", "key2"], &source_path).unwrap();
-
     let destination_path1 = tempdir.path().join("destination-root-1");
     client
         .restore(&["non-existent", "key1"], &destination_path1)
@@ -81,4 +122,22 @@ fn test_roundtrip() {
         fs::read_to_string(destination_path2.join("file.txt")).unwrap(),
         "Hello, world!"
     );
+}
+
+#[test]
+#[serial]
+fn test_cleanup() {
+    let server_with_client = BtdtTestServerWithAuthorizedClient::new(BTreeMap::from([
+        ("BTDT_MAX_CACHE_SIZE".to_string(), "0B".to_string()),
+        ("BTDT_CACHE_EXPIRATION".to_string(), "1s".to_string()),
+        ("BTDT_CLEANUP_INTERVAL".to_string(), "1s".to_string()),
+    ]));
+    let mut client = server_with_client.client;
+    let test_data = TestData::default();
+
+    client.store(&["key"], &test_data.path).unwrap();
+    sleep(Duration::from_secs(2));
+
+    let tempdir = tempdir().unwrap();
+    assert_eq!(client.restore(&["key"], &tempdir).unwrap(), None);
 }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.3.2 -> 0.3.3
* `btdt-cli`: 0.3.2 -> 0.3.3
* `btdt-server`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.3.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.1...btdt-cli-v0.3.2) - 2025-11-18

### Other

- Bump version
</blockquote>

## `btdt-server`

<blockquote>

## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-server-v0.3.2...btdt-server-v0.3.3) - 2025-11-23

### Fixed

- Implement graceful btdt-server shutdown

### Other

- Install libssl-dev to fix build of server binaries
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).