### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.2...btdt-cli-v0.3.3) - 2025-11-30
+
+### Added
+
+- Add `--root-cert` flag to specify custom TLS root certificates
+- Implement background cleanup job in btdt-server
+- Implement btdt-server health-check command
+
+### Other
+
+- Deny unsafe code without safety comment
+
 ## [0.3.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.1...btdt-cli-v0.3.2) - 2025-11-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.3.2" }
+btdt = { path = "../btdt", version = "0.3.3" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `btdt-cli`: 0.3.2 -> 0.3.3
* `btdt-server`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.2...btdt-cli-v0.3.3) - 2025-11-30

### Added

- Add `--root-cert` flag to specify custom TLS root certificates
- Implement background cleanup job in btdt-server
- Implement btdt-server health-check command

### Other

- Deny unsafe code without safety comment
</blockquote>

## `btdt-server`

<blockquote>

## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.2...btdt-cli-v0.3.3) - 2025-11-30

### Added

- Add `--root-cert` flag to specify custom TLS root certificates
- Implement background cleanup job in btdt-server
- Implement btdt-server health-check command

### Other

- Deny unsafe code without safety comment
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).