### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.3...btdt-cli-v0.3.4) - 2025-12-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.2...btdt-cli-v0.3.3) - 2025-11-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.3.3" }
+btdt = { path = "../btdt", version = "0.3.4" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.3.3" }
+btdt = { path = "../btdt", version = "0.3.4" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.3.3 -> 0.3.4
* `btdt-cli`: 0.3.3 -> 0.3.4
* `btdt-server`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.3.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.3...btdt-cli-v0.3.4) - 2025-12-02

### Other

- update Cargo.lock dependencies
</blockquote>

## `btdt-server`

<blockquote>

## [0.3.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.3...btdt-cli-v0.3.4) - 2025-12-02

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).