### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.5...btdt-cli-v0.4.0) - 2025-12-07
+
+### Fixed
+
+- [**breaking**] Disambiguate exit codes
+
+### Other
+
+- [**breaking**] Use actual API url for remote cache specification
+- Fix clippy lint
+- Use module/mod.rs structure consistently
+- Update btdt API documentation
+- clippy lint
+
 ## [0.3.5](https://github.com/jgosmann/btdt/compare/btdt-server-v0.3.4...btdt-server-v0.3.5) - 2025-12-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.3.5" }
+btdt = { path = "../btdt", version = "0.4.0" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.3.5" }
+btdt = { path = "../btdt", version = "0.4.0" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive", "env"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.3.5 -> 0.4.0 (⚠ API breaking changes)
* `btdt-cli`: 0.3.5 -> 0.4.0
* `btdt-server`: 0.3.5 -> 0.4.0 (✓ API compatible changes)

### ⚠ `btdt` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_missing.ron

Failed in:
  variant RemoteCacheError::InvalidCacheId, previously in file /tmp/.tmpT43ACB/btdt/src/cache/remote.rs:50

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  btdt::cache::remote::RemoteCache::new now takes 3 parameters instead of 4, in /tmp/.tmpGAjLGo/btdt/btdt/src/cache/remote.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.4.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.5...btdt-cli-v0.4.0) - 2025-12-07

### Fixed

- [**breaking**] Disambiguate exit codes

### Other

- [**breaking**] Use actual API url for remote cache specification
- Fix clippy lint
- Use module/mod.rs structure consistently
- Update btdt API documentation
- clippy lint
</blockquote>

## `btdt-server`

<blockquote>

## [0.4.0](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.3.5...btdt-cli-v0.4.0) - 2025-12-07

### Fixed

- [**breaking**] Disambiguate exit codes

### Other

- [**breaking**] Use actual API url for remote cache specification
- Fix clippy lint
- Use module/mod.rs structure consistently
- Update btdt API documentation
- clippy lint
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).