### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.1...btdt-cli-v0.4.2) - 2026-02-19
+
+### Fixed
+
+- CLI description text
+
+### Other
+
+- Fix missing word in readme
+- Update documentation for btdt-server
+
 ## [0.4.1](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.0...btdt-cli-v0.4.1) - 2025-12-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.4.1" }
+btdt = { path = "../btdt", version = "0.4.2" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.4.1" }
+btdt = { path = "../btdt", version = "0.4.2" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive", "env"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `btdt-cli`: 0.4.1 -> 0.4.2
* `btdt-server`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.4.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.1...btdt-cli-v0.4.2) - 2026-02-19

### Fixed

- CLI description text

### Other

- Fix missing word in readme
- Update documentation for btdt-server
</blockquote>

## `btdt-server`

<blockquote>

## [0.4.2](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.1...btdt-cli-v0.4.2) - 2026-02-19

### Fixed

- CLI description text

### Other

- Fix missing word in readme
- Update documentation for btdt-server
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).