### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-17
+
+### Added
+
+- *(btdt-cli)* Add support for excluding files from cache archive
+- *(btdt)* Add support for excluding files from cache archive
+
+### Other
+
+- Use custom implementation for adding files to archive
+
 ## [0.4.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.2...btdt-cli-v0.4.3) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.4.3" }
+btdt = { path = "../btdt", version = "0.4.4" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-cli/src/main.rs
+++ b/btdt-cli/src/main.rs
@@ -99,6 +99,10 @@ enum Commands {
 
         /// Directory to store in the cache.
         source_dir: PathBuf,
+
+        /// Paths to exclude from the cached archive.
+        #[arg(long)]
+        exclude: Vec<PathBuf>,
     },
 }
 
@@ -222,10 +226,11 @@ fn main() -> Result<ExitCode, anyhow::Error> {
         Commands::Store {
             entries_ref,
             source_dir,
+            exclude,
         } => {
             entries_ref
                 .to_pipeline()?
-                .store(&entries_ref.keys(), &source_dir)
+                .store_excluding(&entries_ref.keys(), &source_dir, &exclude)
                 .with_context(|| format!("Could not cache: {}", source_dir.display()))?;
         }
         Commands::Restore {

--- a/btdt-cli/tests/test_cli.rs
+++ b/btdt-cli/tests/test_cli.rs
@@ -87,6 +87,57 @@ fn test_roundtrip() {
     }
 }
 
+#[test]
+fn test_exclusion() {
+    let tempdir = tempdir().unwrap();
+    let cache_path = tempdir.path().join("cache");
+    let source_path = tempdir.path().join("source-root");
+    let destination_path = tempdir.path().join("destination-root");
+
+    let spec = DirSpec::create_unix_fixture();
+    spec.create(source_path.as_ref()).unwrap();
+    fs::create_dir(&cache_path).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_btdt"))
+        .arg("store")
+        .arg("--cache")
+        .arg(cache_path.to_str().unwrap())
+        .arg("--keys")
+        .arg("cache-key")
+        .arg(&source_path)
+        .arg("--exclude")
+        .arg("dir/exec-file")
+        .arg("--exclude")
+        .arg("symlink")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "store failed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_btdt"))
+        .arg("restore")
+        .arg("--cache")
+        .arg(cache_path.to_str().unwrap())
+        .arg("--keys")
+        .arg("cache-key")
+        .arg(&destination_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "restore failed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(destination_path.join("file.txt").exists());
+    assert!(!destination_path.join("symlink").exists());
+    assert!(destination_path.join("dir").exists());
+    assert!(!destination_path.join("dir/exec-file").exists());
+}
+
 struct AuthData {
     _key_dir: TempDir,
     key_path: PathBuf,

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.4.3" }
+btdt = { path = "../btdt", version = "0.4.4" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive", "env"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `btdt-cli`: 0.4.3 -> 0.4.4
* `btdt-server`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-17

### Added

- *(btdt-cli)* Add support for excluding files from cache archive
- *(btdt)* Add support for excluding files from cache archive

### Other

- Use custom implementation for adding files to archive
</blockquote>

## `btdt-server`

<blockquote>

## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-17

### Added

- *(btdt-cli)* Add support for excluding files from cache archive
- *(btdt)* Add support for excluding files from cache archive

### Other

- Use custom implementation for adding files to archive
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).