### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-18
+
+### Added
+
+- *(btdt-cli)* Add support for excluding files from cache archive
+- *(btdt)* Add support for excluding files from cache archive
+
+### Other
+
+- Use custom implementation for adding files to archive
+
 ## [0.4.3](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.2...btdt-cli-v0.4.3) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "btdt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "biscuit-auth",
  "blake3",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "biscuit-auth",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "btdt-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "biscuit-auth",
  "btdt",

--- a/btdt-cli/Cargo.toml
+++ b/btdt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 default-run = "btdt"
 authors = ["Jan Gosmann"]
@@ -19,7 +19,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0.95"
-btdt = { path = "../btdt", version = "0.4.3" }
+btdt = { path = "../btdt", version = "0.4.4" }
 blake3 = "1.5.5"
 clap = { version = "4.5.27", features = ["derive", "unstable-markdown"] }
 humantime = "2.1.0"

--- a/btdt-cli/src/main.rs
+++ b/btdt-cli/src/main.rs
@@ -99,6 +99,10 @@ enum Commands {
 
         /// Directory to store in the cache.
         source_dir: PathBuf,
+
+        /// Paths to exclude from the cached archive.
+        #[arg(long)]
+        exclude: Vec<PathBuf>,
     },
 }
 
@@ -222,10 +226,11 @@ fn main() -> Result<ExitCode, anyhow::Error> {
         Commands::Store {
             entries_ref,
             source_dir,
+            exclude,
         } => {
             entries_ref
                 .to_pipeline()?
-                .store(&entries_ref.keys(), &source_dir)
+                .store_excluding(&entries_ref.keys(), &source_dir, &exclude)
                 .with_context(|| format!("Could not cache: {}", source_dir.display()))?;
         }
         Commands::Restore {

--- a/btdt-cli/tests/test_cli.rs
+++ b/btdt-cli/tests/test_cli.rs
@@ -87,6 +87,57 @@ fn test_roundtrip() {
     }
 }
 
+#[test]
+fn test_exclusion() {
+    let tempdir = tempdir().unwrap();
+    let cache_path = tempdir.path().join("cache");
+    let source_path = tempdir.path().join("source-root");
+    let destination_path = tempdir.path().join("destination-root");
+
+    let spec = DirSpec::create_unix_fixture();
+    spec.create(source_path.as_ref()).unwrap();
+    fs::create_dir(&cache_path).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_btdt"))
+        .arg("store")
+        .arg("--cache")
+        .arg(cache_path.to_str().unwrap())
+        .arg("--keys")
+        .arg("cache-key")
+        .arg(&source_path)
+        .arg("--exclude")
+        .arg("dir/exec-file")
+        .arg("--exclude")
+        .arg("symlink")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "store failed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_btdt"))
+        .arg("restore")
+        .arg("--cache")
+        .arg(cache_path.to_str().unwrap())
+        .arg("--keys")
+        .arg("cache-key")
+        .arg(&destination_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "restore failed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(destination_path.join("file.txt").exists());
+    assert!(!destination_path.join("symlink").exists());
+    assert!(destination_path.join("dir").exists());
+    assert!(!destination_path.join("dir/exec-file").exists());
+}
+
 struct AuthData {
     _key_dir: TempDir,
     key_path: PathBuf,

--- a/btdt-server/Cargo.toml
+++ b/btdt-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt-server"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 documentation = "https://jgosmann.github.io/btdt/"
@@ -19,7 +19,7 @@ name = "btdt_server_lib"
 path = "lib/lib.rs"
 
 [dependencies]
-btdt = { path = "../btdt", version = "0.4.3" }
+btdt = { path = "../btdt", version = "0.4.4" }
 bytes = "1.10.1"
 clap = { version = "4.5.53", features = ["derive", "env"] }
 config = { version = "0.15.13", features = ["toml"] }

--- a/btdt/Cargo.toml
+++ b/btdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btdt"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Jan Gosmann"]
 description = "\"been there, done that\" - a tool for flexible CI caching"

--- a/btdt/src/pipeline.rs
+++ b/btdt/src/pipeline.rs
@@ -6,7 +6,7 @@ use crate::error::{IoPathResult, WithPath};
 use crate::util::close::Close;
 use std::fs::File;
 use std::io::{BufWriter, ErrorKind, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tar::{Builder, EntryType, Header};
 
 /// A pipeline defines how multiple files a processed to be stored in the cache.
@@ -80,11 +80,33 @@ impl<C: Cache> Pipeline<C> {
     /// The files in the directory specified by `source` are archived and stored in the cache under
     /// the given keys.
     pub fn store(&mut self, keys: &[&str], source: impl AsRef<Path>) -> IoPathResult<()> {
+        let excludes: [PathBuf; 0] = [];
+        Self::store_excluding(self, keys, source, &excludes)
+    }
+
+    /// Stores the files in the cache.
+    ///
+    /// The files in the directory specified by `source` are archived and stored in the cache under
+    /// the given keys. Paths in `excludes` will be excluded from the archive.
+    pub fn store_excluding(
+        &mut self,
+        keys: &[&str],
+        source: impl AsRef<Path>,
+        excludes: &[impl AsRef<Path>],
+    ) -> IoPathResult<()> {
         let mut writer = BufWriter::new(self.cache.set(keys)?);
         {
             let mut archive = tar::Builder::new(&mut writer);
             archive.follow_symlinks(false);
-            Self::add_dir_to_archive(&mut archive, source.as_ref(), source.as_ref())?;
+            Self::add_dir_to_archive(
+                &mut archive,
+                source.as_ref(),
+                source.as_ref(),
+                &excludes
+                    .iter()
+                    .map(|exclude| source.as_ref().join(exclude))
+                    .collect::<Vec<_>>(),
+            )?;
             archive.finish().with_path(source.as_ref())?;
         }
         writer
@@ -99,6 +121,7 @@ impl<C: Cache> Pipeline<C> {
         archive_builder: &mut Builder<impl Write>,
         path: &Path,
         root: &Path,
+        excludes: &[impl AsRef<Path>],
     ) -> IoPathResult<()> {
         for entry in path.read_dir().with_path(path)? {
             let entry = entry.with_path(path)?;
@@ -106,12 +129,18 @@ impl<C: Cache> Pipeline<C> {
             let archived_path = source_path
                 .strip_prefix(root)
                 .expect("root not a prefix of parth");
+            if excludes
+                .iter()
+                .any(|exclude| exclude.as_ref() == source_path)
+            {
+                continue;
+            }
             let file_type = entry.file_type().with_path(entry.path())?;
             if file_type.is_dir() {
                 archive_builder
                     .append_dir(archived_path, &source_path)
                     .with_path(&source_path)?;
-                Self::add_dir_to_archive(archive_builder, &source_path, root)?;
+                Self::add_dir_to_archive(archive_builder, &source_path, root, excludes)?;
             } else if file_type.is_symlink() {
                 let link_target = std::fs::read_link(&source_path).with_path(&source_path)?;
                 let mut header = Header::new_old();
@@ -167,6 +196,28 @@ mod tests {
         pipeline.restore(&["cache-key"], &destination_path).unwrap();
 
         assert_eq!(spec.compare_with(&destination_path).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn test_exclusion_of_paths() {
+        let cache = LocalCache::new(InMemoryStorage::new());
+        let mut pipeline = Pipeline::new(cache);
+
+        let spec = DirSpec::create_unix_fixture();
+
+        let tempdir = tempdir().unwrap();
+        let source_path = tempdir.path().join("source-root");
+        spec.create(source_path.as_ref()).unwrap();
+        pipeline
+            .store_excluding(&["cache-key"], &source_path, &["symlink", "dir"])
+            .unwrap();
+
+        let destination_path = tempdir.path().join("destination-root");
+        pipeline.restore(&["cache-key"], &destination_path).unwrap();
+
+        assert!(destination_path.join("file.txt").exists());
+        assert!(!destination_path.join("symlink").exists());
+        assert!(!destination_path.join("dir").exists());
     }
 
     #[test]

--- a/doc/src/cli-reference.md
+++ b/doc/src/cli-reference.md
@@ -109,6 +109,11 @@ Path to a file containing the authentication token for accessing a remote cache.
 
 Path to the cache (local directory or remote cache URL).
 
+### `--exclude <EXCLUDE_PATH>`
+
+Path (relative to `<SOURCE_DIR>`) to exclude from the cache.
+This argument can be repeated to specify multiple paths to exclude.
+
 ### `-k <KEYS>`, `--keys <KEYS>`
 
 Comma-separated list of cache keys to store the cached data under.


### PR DESCRIPTION



## 🤖 New release

* `btdt`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `btdt-cli`: 0.4.3 -> 0.4.4
* `btdt-server`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `btdt-cli`

<blockquote>

## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-18

### Added

- *(btdt-cli)* Add support for excluding files from cache archive
- *(btdt)* Add support for excluding files from cache archive

### Other

- Use custom implementation for adding files to archive
</blockquote>

## `btdt-server`

<blockquote>

## [0.4.4](https://github.com/jgosmann/btdt/compare/btdt-cli-v0.4.3...btdt-cli-v0.4.4) - 2026-03-18

### Added

- *(btdt-cli)* Add support for excluding files from cache archive
- *(btdt)* Add support for excluding files from cache archive

### Other

- Use custom implementation for adding files to archive
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).